### PR TITLE
Set reflection property to accessible in PrivateStaticMiddleware

### DIFF
--- a/.changeset/mighty-gorillas-talk.md
+++ b/.changeset/mighty-gorillas-talk.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Set reflection property to accessible in PrivateStaticMiddleware

--- a/e2e/basic-app/app/src/Page.php
+++ b/e2e/basic-app/app/src/Page.php
@@ -1,16 +1,37 @@
 <?php
 
-use App\Model\Block;
-use App\Page\Extension\AlternativeTitleExtension;
-use SilverStripe\CMS\Model\SiteTree;
+namespace {
 
-class Page extends SiteTree
-{
-    private static array $has_many = [
-        'Blocks' => Block::class,
-    ];
+    use App\Model\Block;
+    use App\Model\Block\ContentBlock;
+    use App\Page\Extension\AlternativeTitleExtension;
+    use SilverStripe\CMS\Model\SiteTree;
+    use SilverStripe\ORM\ArrayList;
 
-    private static array $extensions = [
-        AlternativeTitleExtension::class,
-    ];
+    class Page extends SiteTree
+    {
+        private static array $has_many = [
+            'Blocks' => Block::class,
+        ];
+
+        private static array $extensions = [
+            AlternativeTitleExtension::class,
+        ];
+
+        public function getTitle(): string
+        {
+            if ($this->AlternativeTitle !== null && $this->AlternativeTitle !== '') {
+                return $this->AlternativeTitle;
+            }
+
+            return parent::getTitle();
+        }
+
+        public function getContentBlocks(): ArrayList
+        {
+            return $this->Blocks()->filterByCallback(static function (Block $block): bool {
+                return $block instanceof ContentBlock;
+            });
+        }
+    }
 }

--- a/e2e/basic-app/app/src/PageController.php
+++ b/e2e/basic-app/app/src/PageController.php
@@ -1,10 +1,10 @@
 <?php
 
-use SilverStripe\CMS\Controllers\ContentController;
+namespace {
 
-class PageController extends ContentController
-{
-    private static array $has_many = [
-        'Blocks' => 'HTMLText',
-    ];
+    use SilverStripe\CMS\Controllers\ContentController;
+
+    class PageController extends ContentController
+    {
+    }
 }

--- a/e2e/basic-module/src/Page/Extension/IsFeaturedExtension.php
+++ b/e2e/basic-module/src/Page/Extension/IsFeaturedExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Extension\Page;
+namespace App\Page\Extension;
 
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\CheckboxField;

--- a/ecs.php
+++ b/ecs.php
@@ -11,6 +11,7 @@ return ECSConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/e2e',
     ])
     ->withConfiguredRule(
         NewWithParenthesesFixer::class,

--- a/src/ConfigurationResolver/Middleware/PrivateStaticMiddleware.php
+++ b/src/ConfigurationResolver/Middleware/PrivateStaticMiddleware.php
@@ -68,6 +68,7 @@ final class PrivateStaticMiddleware extends AbstractMiddleware
 
             // Accessing the value may throw an exception if the value does not exist
             try {
+                $nativePropertyReflection->setAccessible(true);
                 $classConfig[$nativePropertyReflection->getName()] = $nativePropertyReflection->getValue();
             } catch (Throwable) {
                 continue;


### PR DESCRIPTION
## Description ✍️

- Accessing a private property in ReflectionClass will throw an error (php 7.4)
- Update e2e stubs

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
