### PR TITLE
Add preliminary support for Silverstripe 6.x

### DIFF
--- a/.changeset/tall-hairs-study.md
+++ b/.changeset/tall-hairs-study.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": minor
+---
+
+Add preliminary support for Silverstripe 6.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,12 @@ jobs:
             cms-version: 5.1
           - directory: e2e/basic-app
             php-version: 8.1
-            framework-version: 5.3
-            cms-version: 5.3
+            framework-version: 5.4
+            cms-version: 5.4
+          - directory: e2e/basic-app
+            php-version: 8.3
+            framework-version: 6.0
+            cms-version: 6.0
           - directory: e2e/basic-module
             php-version: 7.4
             framework-version: 4.13
@@ -41,8 +45,12 @@ jobs:
             cms-version: 5.1
           - directory: e2e/basic-module
             php-version: 8.1
-            framework-version: 5.3
-            cms-version: 5.3
+            framework-version: 5.4
+            cms-version: 5.4
+          - directory: e2e/basic-module
+            php-version: 8.3
+            framework-version: 6.0
+            cms-version: 6.0
     steps:
       # Build source code
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Silverstripe 5.2 introduces [generic typehints](https://docs.silverstripe.org/en
 
 To make the best use of this module, make sure that your classes are correctly annotated using a combination of generics, and property/method annotations.
 
+## Bleeding edge 🔪
+
+New and experimental features are available via the bleeding edge config. You can opt in by including the relevant config file.
+
+```neon
+includes:
+    - vendor/cambis/silverstan/bleedingEdge.neon
+```
+
 ## Rules 🚨
 Silverstan provides a set of customisable rules that can help make your application safer.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Here are some of the nice features this extension provides:
 - Correct return types for `SilverStripe\Core\Extension::$owner` and `SilverStripe\Core\Extension::getOwner()`.
 - Correct return types for `SilverStripe\Core\Injector\Injector::get()` and `SilverStripe\Core\Injector\Injector::create()`.
 - Correct return type for `SilverStripe\ORM\DataObject::dbObject()`.
+- Type specification for `SilverStripe\Model\ModelData::hasField()` method.
 - Type specification for `SilverStripe\View\ViewableData::hasField()` method.
 - Various correct return types for commonly used Silverstripe modules.
 - [Customisable rules to help make your application safer](docs/rules_overview.md).
@@ -81,7 +82,7 @@ You can use [Silverstripe Rector](https://github.com/Cambis/silverstripe-rector)
 
 Silverstan provides type specifying extensions for these cases. However, these extensions can only be applied on a per class basis.
 
-The default configuration applies these extensions to `SilverStripe\View\ViewableData` only. If you wish to add them to other `SilverStripe\Core\Extensible` classes that aren't subclasses of the former you can use the following configuration:
+The default configuration applies these extensions to `SilverStripe\View\ViewableData` and `SilverStripe\Model\ModelData` only. If you wish to add them to other `SilverStripe\Core\Extensible` classes that aren't subclasses of the former you can use the following configuration:
 
 ```yml
 services:

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -27,6 +27,14 @@ if (in_array(__DIR__ . '/silverstripe-autoloader.php', $bootstrapFiles)) {
     return;
 }
 
+foreach ($bootstrapFiles as $bootstrapFile) {
+    if (!str_contains($bootstrapFile, 'cambis/silverstan/silverstripe-autoloader.php')) {
+        continue;
+    }
+
+    return;
+}
+
 // Don't continue if there is no Silverstripe installation
 if (!class_exists('SilverStripe\Core\Config\Config')) {
     throw new ShouldNotHappenException('Could not find `silverstripe/framework`, did you forget to install?');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -37,14 +37,14 @@ foreach ($bootstrapFiles as $bootstrapFile) {
 
 // Don't continue if there is no Silverstripe installation
 if (!class_exists('SilverStripe\Core\Config\Config')) {
-    throw new ShouldNotHappenException('Could not find `silverstripe/framework`, did you forget to install?');
+    throw new ShouldNotHappenException("\n\nCould not find `silverstripe/framework`, did you forget to install?\n");
 }
 
 /** @var array{includeTestOnly: bool} $silverstanParams */
 $silverstanParams = $container->getParameter('silverstan');
 
 // We don't need access to the database
-DB::set_conn(new NullDatabase());
+DB::set_conn(new NullDatabase(), 'default');
 
 // Ensure that the proper globals are set
 $globalVars = Environment::getVariables();

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -18,7 +18,7 @@
     "ext-tokenizer": "*",
     "composer/class-map-generator": "^1.5",
     "phpstan/phpstan": "^1.12",
-    "silverstripe/config": "^1.4 || ^2.0",
+    "silverstripe/config": "^1.4 || ^2.0 || ^3.0",
     "symplify/rule-doc-generator-contracts": "^9.3 || ^10.0 || ^11.0"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-tokenizer": "*",
         "composer/class-map-generator": "^1.5",
         "phpstan/phpstan": "^1.12",
-        "silverstripe/config": "^1.4 || ^2.0",
+        "silverstripe/config": "^1.4 || ^2.0 || ^3.0",
         "symplify/rule-doc-generator-contracts": "^9.3 || ^10.0 || ^11.0"
     },
     "require-dev": {

--- a/e2e/basic-app/composer.json
+++ b/e2e/basic-app/composer.json
@@ -3,8 +3,8 @@
   "description": "",
   "require": {
     "php": "^8.1",
-    "silverstripe/cms": "^5.3",
-    "silverstripe/framework": "^5.3"
+    "silverstripe/cms": "^5",
+    "silverstripe/framework": "^5"
   },
   "require-dev": {
     "cambis/silverstan": "dev-main"
@@ -15,6 +15,8 @@
       "url": "../../"
     }
   ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "config": {
     "allow-plugins": {
       "composer/installers": true,

--- a/e2e/basic-app/phpstan-baseline.neon
+++ b/e2e/basic-app/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+    ignoreErrors:
+    -
+      message: "#^Method Page\\:\\:getContentBlocks\\(\\) has invalid return type SilverStripe\\\\ORM\\\\ArrayList\\.$#"
+      count: 1
+      path: app/src/Page.php
+      reportUnmatched: false
+
+    -
+      message: "#^Method Page\\:\\:getContentBlocks\\(\\) should return SilverStripe\\\\ORM\\\\ArrayList but returns SilverStripe\\\\Model\\\\List\\\\ArrayList\\<App\\\\Model\\\\Block\\>\\.$#"
+      count: 1
+      path: app/src/Page.php
+      reportUnmatched: false

--- a/e2e/basic-app/phpstan.neon.dist
+++ b/e2e/basic-app/phpstan.neon.dist
@@ -1,8 +1,9 @@
 includes:
     - vendor/cambis/silverstan/extension.neon
     - vendor/cambis/silverstan/bleedingEdge.neon
+    - phpstan-baseline.neon
 parameters:
-    level: 9
+    level: max
     paths:
         - app/src
     ignoreErrors:

--- a/e2e/basic-module/composer.json
+++ b/e2e/basic-module/composer.json
@@ -4,8 +4,8 @@
   "description": "",
   "require": {
     "php": "^8.1",
-    "silverstripe/cms": "^5.3",
-    "silverstripe/framework": "^5.3"
+    "silverstripe/cms": "^5",
+    "silverstripe/framework": "^5"
   },
   "require-dev": {
     "cambis/silverstan": "dev-main"
@@ -16,6 +16,8 @@
       "url": "../../"
     }
   ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "config": {
     "allow-plugins": {
       "composer/installers": true,

--- a/e2e/basic-module/phpstan.neon.dist
+++ b/e2e/basic-module/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - vendor/cambis/silverstan/extension.neon
     - vendor/cambis/silverstan/bleedingEdge.neon
 parameters:
-    level: 9
+    level: max
     paths:
         - src
     ignoreErrors:

--- a/extension.neon
+++ b/extension.neon
@@ -55,24 +55,47 @@ services:
     -
         class: Cambis\Silverstan\Extension\Type\DataObjectWriteTypeSpecifyingExtension
         tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
+    # silverstripe/framework: <= 6.x
     -
         class: Cambis\Silverstan\Extension\Type\ExtensibleHasExtensionTypeSpecifyingExtension
         tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
         arguments:
             className: 'SilverStripe\View\ViewableData'
+    # silverstripe/framework: >= 6.x
+    -
+        class: Cambis\Silverstan\Extension\Type\ExtensibleHasExtensionTypeSpecifyingExtension
+        tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
+        arguments:
+            className: 'SilverStripe\Model\ModelData'
+    # silverstripe/framework: <= 6.x
     -
         class: Cambis\Silverstan\Extension\Type\ExtensibleHasMethodTypeSpecifyingExtension
         tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
         arguments:
             className: 'SilverStripe\View\ViewableData'
+    # silverstripe/framework: >= 6.x
+    -
+        class: Cambis\Silverstan\Extension\Type\ExtensibleHasMethodTypeSpecifyingExtension
+        tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
+        arguments:
+            className: 'SilverStripe\Model\ModelData'
     -
         class: Cambis\Silverstan\Extension\Type\InjectorGetReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
     -
         class: Cambis\Silverstan\Extension\Type\SingletonReturnTypeExtension
         tags: [phpstan.broker.dynamicFunctionReturnTypeExtension]
+    # silverstripe/framework <= 6.x
     -
         class: Cambis\Silverstan\Extension\Type\ViewableDataHasFieldTypeSpecifyingExtension
+        arguments:
+          className: 'SilverStripe\View\ViewableData'
+        tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
+    # silverstripe/framework >= 6.x
+    -
+        class: Cambis\Silverstan\Extension\Type\ViewableDataHasFieldTypeSpecifyingExtension
+        arguments:
+          className: 'SilverStripe\Model\ModelData'
         tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
     -
         class: Cambis\Silverstan\NodeVisitor\PropertyFetchAssignedToVisitor

--- a/src/Application/SilverstanKernel.php
+++ b/src/Application/SilverstanKernel.php
@@ -10,10 +10,16 @@ use SilverStripe\Core\DatabaselessKernel;
 use function class_exists;
 
 /**
+ * `DatabaselessKernel` does not exist in 6.x. Throw an exception and indicate to the user
+ * that they need to opt in to the bleeding edge config.
+ *
  * @phpstan-ignore classConstant.deprecatedClass
  */
 if (!class_exists(DatabaselessKernel::class)) {
-    throw new ShouldNotHappenException('Could not find `silverstripe/framework`, did you forget to install?');
+    throw new ShouldNotHappenException("\n
+        The legacy autoloader is not supported on this version of Silverstripe.
+        Opt-in to the bleeding edge config: https://github.com/Cambis/silverstan?tab=readme-ov-file#bleeding-edge- in order to get support.
+    ");
 }
 
 /**

--- a/src/Application/SilverstanKernel.php
+++ b/src/Application/SilverstanKernel.php
@@ -9,12 +9,16 @@ use PHPStan\ShouldNotHappenException;
 use SilverStripe\Core\DatabaselessKernel;
 use function class_exists;
 
+/**
+ * @phpstan-ignore classConstant.deprecatedClass
+ */
 if (!class_exists(DatabaselessKernel::class)) {
     throw new ShouldNotHappenException('Could not find `silverstripe/framework`, did you forget to install?');
 }
 
 /**
  * @deprecated since 1.0.0
+ * @phpstan-ignore-next-line classConstant.deprecatedClass
  */
 final class SilverstanKernel extends DatabaselessKernel
 {

--- a/src/Extension/Reflection/ViewableDataClassReflectionExtension.php
+++ b/src/Extension/Reflection/ViewableDataClassReflectionExtension.php
@@ -11,7 +11,7 @@ use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 
 /**
- * This extension resolves `SilverStripe\View\ViewableData` magic properties.
+ * This extension resolves `SilverStripe\View\ViewableData` and `SilverStripe\Model\ModelData` magic properties.
  *
  * @see \Cambis\Silverstan\Tests\Extension\Reflection\ViewableDataClassReflectionExtensionTest
  */
@@ -30,11 +30,13 @@ final readonly class ViewableDataClassReflectionExtension implements PropertiesC
             return false;
         }
 
+        // silverstripe/framework <= 6.x
         if ($classReflection->is('SilverStripe\View\ViewableData')) {
             return true;
         }
 
-        return $classReflection->isSubclassOf('SilverStripe\View\ViewableData');
+        // silverstripe/framework >= 6.x
+        return $classReflection->is('SilverStripe\Model\ModelData');
     }
 
     #[Override]

--- a/src/Extension/Type/ViewableDataHasFieldTypeSpecifyingExtension.php
+++ b/src/Extension/Type/ViewableDataHasFieldTypeSpecifyingExtension.php
@@ -31,10 +31,18 @@ final class ViewableDataHasFieldTypeSpecifyingExtension implements MethodTypeSpe
 
     private TypeSpecifier $typeSpecifier;
 
+    public function __construct(
+        /**
+         * @var class-string
+         */
+        private readonly string $className
+    ) {
+    }
+
     #[Override]
     public function getClass(): string
     {
-        return 'SilverStripe\View\ViewableData';
+        return $this->className;
     }
 
     #[Override]

--- a/src/TypeResolver/TypeResolver/ManyRelationMethodTypeResolver.php
+++ b/src/TypeResolver/TypeResolver/ManyRelationMethodTypeResolver.php
@@ -12,6 +12,7 @@ use Cambis\Silverstan\TypeResolver\Contract\TypeResolverAwareInterface;
 use Cambis\Silverstan\TypeResolver\TypeResolver;
 use Override;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\GenericObjectType;
 use function array_key_exists;
 use function is_array;
@@ -25,6 +26,7 @@ final class ManyRelationMethodTypeResolver implements MethodTypeResolverInterfac
         private readonly string $configurationPropertyName,
         private readonly ConfigurationResolver $configurationResolver,
         private readonly string $listName,
+        private readonly ReflectionProvider $reflectionProvider,
         private readonly TypeFactory $typeFactory,
         /**
          * @var true|int-mask-of<ConfigurationResolver::EXCLUDE_*>
@@ -49,6 +51,10 @@ final class ManyRelationMethodTypeResolver implements MethodTypeResolverInterfac
     public function resolve(ClassReflection $classReflection): array
     {
         if (!$this->classReflectionAnalyser->isDataObject($classReflection)) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->hasClass($this->listName)) {
             return [];
         }
 

--- a/src/TypeResolver/TypeResolver/ManyRelationMethodTypeResolver.php
+++ b/src/TypeResolver/TypeResolver/ManyRelationMethodTypeResolver.php
@@ -12,7 +12,6 @@ use Cambis\Silverstan\TypeResolver\Contract\TypeResolverAwareInterface;
 use Cambis\Silverstan\TypeResolver\TypeResolver;
 use Override;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\GenericObjectType;
 use function array_key_exists;
 use function is_array;
@@ -26,7 +25,6 @@ final class ManyRelationMethodTypeResolver implements MethodTypeResolverInterfac
         private readonly string $configurationPropertyName,
         private readonly ConfigurationResolver $configurationResolver,
         private readonly string $listName,
-        private readonly ReflectionProvider $reflectionProvider,
         private readonly TypeFactory $typeFactory,
         /**
          * @var true|int-mask-of<ConfigurationResolver::EXCLUDE_*>
@@ -51,10 +49,6 @@ final class ManyRelationMethodTypeResolver implements MethodTypeResolverInterfac
     public function resolve(ClassReflection $classReflection): array
     {
         if (!$this->classReflectionAnalyser->isDataObject($classReflection)) {
-            return [];
-        }
-
-        if (!$this->reflectionProvider->hasClass($this->listName)) {
             return [];
         }
 

--- a/stubs/SilverStripe/ORM/FieldType/DBField.stub
+++ b/stubs/SilverStripe/ORM/FieldType/DBField.stub
@@ -2,9 +2,6 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\ORM\FieldType\DBIndexable;
-use SilverStripe\View\ViewableData;
-
 abstract class DBField
 {
     /**


### PR DESCRIPTION
## Description ✍️

- Add preliminary support for Silverstripe 6.x
- Test suite still runs on Silverstripe 5.x, this will be updated to run on 6.x in version 2.x of this extension
- MUST opt-in to bleeding edge config

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
