### PR TITLE
Report usage of `DataObject::getCMSValidator()`

### DIFF
--- a/.changeset/long-birds-grab.md
+++ b/.changeset/long-birds-grab.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": minor
+---
+
+Report usage of deprecated DataObject::getCMSValidator() method

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -17,7 +17,7 @@
     "php": "^7.4 || ^8.0",
     "ext-tokenizer": "*",
     "composer/class-map-generator": "^1.5",
-    "phpstan/phpstan": "^2.1.7",
+    "phpstan/phpstan": "^2.1.12",
     "silverstripe/config": "^1.4 || ^2.0 || ^3.0"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "ext-tokenizer": "*",
         "composer/class-map-generator": "^1.5",
-        "phpstan/phpstan": "^2.1.7",
+        "phpstan/phpstan": "^2.1.12",
         "silverstripe/config": "^1.4 || ^2.0 || ^3.0"
     },
     "require-dev": {

--- a/extension.neon
+++ b/extension.neon
@@ -80,6 +80,9 @@ services:
         class: Cambis\Silverstan\Reflection\ClassReflectionExtension\ViewableDataClassReflectionExtension
         tags: [phpstan.broker.propertiesClassReflectionExtension]
     -
+        class: Cambis\Silverstan\Reflection\Deprecation\MethodDeprecationExtension\DataObjectGetCMSValidatorMethodDeprecationExtension
+        tags: [phpstan.methodDeprecationExtension]
+    -
         class: Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser
     -
         class: Cambis\Silverstan\ReflectionAnalyser\PropertyReflectionAnalyser

--- a/src/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtension.php
+++ b/src/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\Silverstan\Reflection\Deprecation\MethodDeprecationExtension;
+
+use PHPStan\Reflection\Deprecation\Deprecation;
+use PHPStan\Reflection\Deprecation\MethodDeprecationExtension;
+use ReflectionMethod;
+use function sprintf;
+use function strtolower;
+
+/**
+ * This extension reports usage of the deprecated `DataObject::getCMSValidator()` method.
+ *
+ * @see \Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\DataObjectGetCMSValidatorMethodDeprecationExtensionTest;
+ */
+final class DataObjectGetCMSValidatorMethodDeprecationExtension implements MethodDeprecationExtension
+{
+    public function getMethodDeprecation(ReflectionMethod $reflectionMethod): ?Deprecation
+    {
+        if (!$reflectionMethod->getDeclaringClass()->isSubclassOf('SilverStripe\ORM\DataObject')) {
+            return null;
+        }
+
+        if (strtolower($reflectionMethod->getName()) !== 'getcmsvalidator') {
+            return null;
+        }
+
+        // Don't report if `getCMSCompositeValidator()` does not exist, as we are probably on an older version of Silverstripe
+        if (!$reflectionMethod->getDeclaringClass()->hasMethod('getCMSCompositeValidator')) {
+            return null;
+        }
+
+        return Deprecation::createWithDescription(sprintf(
+            'use %s::getCMSCompositeValidator() instead. See https://docs.silverstripe.org/en/5/developer_guides/forms/validation/#validation-in-the-cms.',
+            $reflectionMethod->getDeclaringClass()->getName()
+        ));
+    }
+}

--- a/tests/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtensionTest.php
+++ b/tests/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension;
+
+use Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\Source\Model\Foo;
+use Override;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Testing\PHPStanTestCase;
+
+final class DataObjectGetCMSValidatorMethodDeprecationExtensionTest extends PHPStanTestCase
+{
+    public function testDeprecation(): void
+    {
+        $reflectionProvider = self::createReflectionProvider();
+        $fixtureClass = $reflectionProvider->getClass(Foo::class);
+
+        $this->assertTrue($fixtureClass->getMethod('getCMSValidator', new OutOfClassScope())->isDeprecated()->yes());
+        $this->assertSame(
+            'use Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\Source\Model\Foo::getCMSCompositeValidator() instead. See https://docs.silverstripe.org/en/5/developer_guides/forms/validation/#validation-in-the-cms.',
+            $fixtureClass->getMethod('getCMSValidator', new OutOfClassScope())->getDeprecatedDescription()
+        );
+    }
+
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../tests.neon'];
+    }
+}

--- a/tests/Reflection/Deprecation/MethodDeprecationExtension/Source/Model/Foo.php
+++ b/tests/Reflection/Deprecation/MethodDeprecationExtension/Source/Model/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\Source\Model;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+    public function getCMSValidator(): void
+    {
+    }
+}


### PR DESCRIPTION
## Description ✍️

- Report usage of deprecated `DataObject::getCMSValidator()` method.

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
