### PR TITLE
Update `FileFinder::getAppRootDirectory()` priority

### DIFF
--- a/.changeset/plenty-dryers-live.md
+++ b/.changeset/plenty-dryers-live.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+update FileFinder::getAppRootDirectory() priority

--- a/src/FileFinder/FileFinder.php
+++ b/src/FileFinder/FileFinder.php
@@ -83,16 +83,21 @@ final class FileFinder
      */
     public function getAppRootDirectory(): string
     {
-        foreach (InstalledVersions::getAllRawData() as $data) {
-            if (!isset($data['versions']['silverstripe/framework']) && !isset($data['versions']['silverstripe/config'])) {
-                continue;
-            }
+        // Check for silverstripe/framework
+        $path = $this->getPackageInstallPath('silverstripe/framework');
 
-            $path = realpath($data['root']['install_path']);
-
-            return $path !== false ? $path : $data['root']['install_path'];
+        if ($path !== null) {
+            return $path;
         }
 
+        // Fallback to silverstripe/config
+        $path = $this->getPackageInstallPath('silverstripe/config');
+
+        if ($path !== null) {
+            return $path;
+        }
+
+        // Final fallback to root package
         $root = InstalledVersions::getRootPackage();
         $path = realpath($root['install_path']);
 
@@ -273,5 +278,20 @@ final class FileFinder
         $this->appDirectories = $appDirs;
 
         return $this->appDirectories;
+    }
+
+    private function getPackageInstallPath(string $packageName): ?string
+    {
+        foreach (InstalledVersions::getAllRawData() as $data) {
+            if (!isset($data['versions'][$packageName])) {
+                continue;
+            }
+
+            $path = realpath($data['root']['install_path']);
+
+            return $path !== false ? $path : $data['root']['install_path'];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Description ✍️

- This function will incorrectly report the global directory as the root directory if the package is installed globally. Search for silverstripe/framework first.
- See #4

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
