### PR TITLE
Add DisallowUsageOfDeprecatedConfigurationPropertyRule

### DIFF
--- a/.changeset/stupid-bottles-listen.md
+++ b/.changeset/stupid-bottles-listen.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Add DisallowUsageOfDeprecatedConfigurationPropertyRule (Bleeding edge)

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -1,0 +1,4 @@
+parameters:
+    silverstan:
+        disallowUsageOfDeprecatedConfigurationProperty:
+            enabled: %deprecationRulesInstalled%

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -150,6 +150,27 @@ final class Bar extends Foo
 
 <br>
 
+## DisallowUsageOfDeprecatedConfigurationPropertyRule
+
+Disallow usage of depercated configuration properties.
+
+Currently available via [bleeding edge](../README.md#bleeding-edge-).
+
+Automatically enabled if [PHPStan deprecation rules](https://github.com/phpstan/phpstan-deprecation-rules) is installed.
+
+:wrench: **configure it!**
+
+- class: [`Cambis\Silverstan\Rule\ClassPropertyNode\DisallowUsageOfDeprecatedConfigurationPropertyRule`](../src/Rule/ClassPropertyNode/DisallowUsageOfDeprecatedConfigurationPropertyRule.php)
+
+```yaml
+parameters:
+    silverstan:
+        disallowUsageOfDeprecatedConfigurationProperty:
+            enabled: true
+```
+
+<br>
+
 ## DisallowPropertyFetchOnConfigForClassRule
 
 Disallow property fetch on `SilverStripe\Core\Config\Config_ForClass`. PHPStan cannot resolve the type of the property, use `self::config()->get('property_name')` instead.

--- a/rules.neon
+++ b/rules.neon
@@ -16,6 +16,8 @@ parameters:
                     method: requireDefaultRecords
         disallowOverridingOfConfigurationPropertyType:
             enabled: true
+        disallowUsageOfDeprecatedConfigurationProperty:
+            enabled: false
         requireConfigurationPropertyOverride:
             enabled: true
             classes:
@@ -48,6 +50,9 @@ parametersSchema:
             )
         ])
         disallowOverridingOfConfigurationPropertyType: structure([
+            enabled: bool()
+        ])
+        disallowUsageOfDeprecatedConfigurationProperty: structure([
             enabled: bool()
         ])
         requireConfigurationPropertyOverride: structure([
@@ -85,6 +90,8 @@ conditionalTags:
         phpstan.rules.rule: %silverstan.requireParentCallInOverridenMethod.enabled%
     Cambis\Silverstan\Rule\ClassPropertyNode\DisallowOverridingOfConfigurationPropertyTypeRule:
         phpstan.rules.rule: %silverstan.disallowOverridingOfConfigurationPropertyType.enabled%
+    Cambis\Silverstan\Rule\ClassPropertyNode\DisallowUsageOfDeprecatedConfigurationPropertyRule:
+        phpstan.rules.rule: %silverstan.disallowUsageOfDeprecatedConfigurationProperty.enabled%
     Cambis\Silverstan\Rule\InClassNode\RequireConfigurationPropertyOverrideRule:
         phpstan.rules.rule: %silverstan.requireConfigurationPropertyOverride.enabled%
     Cambis\Silverstan\Rule\MethodCall\DisallowMethodCallOnUnsafeDataObjectRule:
@@ -105,6 +112,8 @@ services:
             classes: %silverstan.requireParentCallInOverridenMethod.classes%
     -
         class: Cambis\Silverstan\Rule\ClassPropertyNode\DisallowOverridingOfConfigurationPropertyTypeRule
+    -
+        class: Cambis\Silverstan\Rule\ClassPropertyNode\DisallowUsageOfDeprecatedConfigurationPropertyRule
     -
         class: Cambis\Silverstan\Rule\InClassNode\RequireConfigurationPropertyOverrideRule
         arguments:

--- a/src/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtension.php
+++ b/src/Reflection/Deprecation/MethodDeprecationExtension/DataObjectGetCMSValidatorMethodDeprecationExtension.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Cambis\Silverstan\Reflection\Deprecation\MethodDeprecationExtension;
 
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
 use PHPStan\Reflection\Deprecation\Deprecation;
 use PHPStan\Reflection\Deprecation\MethodDeprecationExtension;
-use ReflectionMethod;
 use function sprintf;
 use function strtolower;
 
 /**
  * This extension reports usage of the deprecated `DataObject::getCMSValidator()` method.
  *
- * @see \Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\DataObjectGetCMSValidatorMethodDeprecationExtensionTest;
+ * @see \Cambis\Silverstan\Tests\Reflection\Deprecation\MethodDeprecationExtension\DataObjectGetCMSValidatorMethodDeprecationExtensionTest
  */
 final class DataObjectGetCMSValidatorMethodDeprecationExtension implements MethodDeprecationExtension
 {

--- a/src/Rule/ClassPropertyNode/DisallowUsageOfDeprecatedConfigurationPropertyRule.php
+++ b/src/Rule/ClassPropertyNode/DisallowUsageOfDeprecatedConfigurationPropertyRule.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\Silverstan\Rule\ClassPropertyNode;
+
+use Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser;
+use Cambis\Silverstan\ReflectionAnalyser\PropertyReflectionAnalyser;
+use Cambis\Silverstan\ReflectionResolver\ReflectionResolver;
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function rtrim;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassPropertyNode>
+ *
+ * @see \Cambis\Silverstan\Tests\Rule\ClassPropertyNode\DisallowUseOfDeprecatedConfigurationPropertyRuleTest
+ */
+final readonly class DisallowUsageOfDeprecatedConfigurationPropertyRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const IDENTIFIER = 'silverstan.configurationProperty.isDeprecated';
+
+    public function __construct(
+        private ClassReflectionAnalyser $classReflectionAnalyser,
+        private PropertyReflectionAnalyser $propertyReflectionAnalyser,
+        private ReflectionResolver $reflectionResolver
+    ) {
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassPropertyNode::class;
+    }
+
+    /**
+     * @param ClassPropertyNode $node
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->propertyReflectionAnalyser->isConfigurationProperty($node)) {
+            return [];
+        }
+
+        $classReflection = $node->getClassReflection();
+
+        if (!$classReflection->hasNativeProperty($node->getName())) {
+            return [];
+        }
+
+        if (!$this->classReflectionAnalyser->isConfigurable($classReflection)) {
+            return [];
+        }
+
+        $prototype = $this->reflectionResolver->resolveConfigurationPropertyReflection($classReflection->getParentClass(), $node->getName());
+
+        if (!$prototype instanceof PropertyReflection) {
+            return [];
+        }
+
+        if ($prototype->isDeprecated()->no()) {
+            return [];
+        }
+
+        $message = sprintf(
+            'Access to deprecated configuration property $%s of class %s.',
+            $node->getName(),
+            $prototype->getDeclaringClass()->getName(),
+        );
+
+        $description = $prototype->getDeprecatedDescription();
+
+        if ($description !== null) {
+            $message = sprintf("%s:\n%s.", rtrim($message, '.'), rtrim($description, '.'));
+        }
+
+        return [
+            RuleErrorBuilder::message($message)->identifier(self::IDENTIFIER)->build(),
+        ];
+    }
+}

--- a/tests/Rule/ClassPropertyNode/DisallowUseOfDeprecatedConfigurationPropertyRuleTest.php
+++ b/tests/Rule/ClassPropertyNode/DisallowUseOfDeprecatedConfigurationPropertyRuleTest.php
@@ -7,22 +7,26 @@ namespace Cambis\Silverstan\Tests\Rule\ClassPropertyNode;
 use Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser;
 use Cambis\Silverstan\ReflectionAnalyser\PropertyReflectionAnalyser;
 use Cambis\Silverstan\ReflectionResolver\ReflectionResolver;
-use Cambis\Silverstan\Rule\ClassPropertyNode\DisallowOverridingOfConfigurationPropertyTypeRule;
+use Cambis\Silverstan\Rule\ClassPropertyNode\DisallowUsageOfDeprecatedConfigurationPropertyRule;
 use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<DisallowOverridingOfConfigurationPropertyTypeRule>
+ * @extends RuleTestCase<DisallowUsageOfDeprecatedConfigurationPropertyRule>
  */
-final class DisallowOverridingOfConfigurationPropertyTypeRuleTest extends RuleTestCase
+final class DisallowUseOfDeprecatedConfigurationPropertyRuleTest extends RuleTestCase
 {
     public function testRule(): void
     {
         $this->analyse([__DIR__ . '/Fixture/Bar.php'], [
             [
-                'Type string|null of configuration property Cambis\Silverstan\Tests\Rule\ClassPropertyNode\Fixture\Bar::$table_name is not the same as type string of overridden configuration property SilverStripe\ORM\DataObject::$table_name.',
-                11,
+                'Access to deprecated configuration property $deprecated_property of class Cambis\Silverstan\Tests\Rule\ClassPropertyNode\Fixture\Foo.',
+                13,
+            ],
+            [
+                "Access to deprecated configuration property \$deprecated_property_with_message of class Cambis\\Silverstan\\Tests\\Rule\\ClassPropertyNode\\Fixture\\Foo:\nreason.",
+                15,
             ],
         ]);
     }
@@ -38,7 +42,7 @@ final class DisallowOverridingOfConfigurationPropertyTypeRuleTest extends RuleTe
     #[Override]
     protected function getRule(): Rule
     {
-        return new DisallowOverridingOfConfigurationPropertyTypeRule(
+        return new DisallowUsageOfDeprecatedConfigurationPropertyRule(
             self::getContainer()->getByType(ClassReflectionAnalyser::class),
             self::getContainer()->getByType(PropertyReflectionAnalyser::class),
             self::getContainer()->getByType(ReflectionResolver::class)

--- a/tests/Rule/ClassPropertyNode/Fixture/Bar.php
+++ b/tests/Rule/ClassPropertyNode/Fixture/Bar.php
@@ -3,11 +3,14 @@
 namespace Cambis\Silverstan\Tests\Rule\ClassPropertyNode\Fixture;
 
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\ORM\DataObject;
 
-final class DisallowOverridingName extends DataObject implements TestOnly
+final class Bar extends Foo implements TestOnly
 {
     private static array $db = [];
 
     private static string|null $table_name = 'MyTable';
+
+    private static string $deprecated_property = '';
+
+    private static string $deprecated_property_with_message = '';
 }

--- a/tests/Rule/ClassPropertyNode/Fixture/Foo.php
+++ b/tests/Rule/ClassPropertyNode/Fixture/Foo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cambis\Silverstan\Tests\Rule\ClassPropertyNode\Fixture;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Foo extends DataObject implements TestOnly
+{
+    /**
+     * @deprecated
+     */
+    private static string $deprecated_property = '';
+
+    /**
+     * @deprecated reason
+     */
+    private static string $deprecated_property_with_message = '';
+}


### PR DESCRIPTION
## Description ✍️

- This rule is used to detect usage of deprecated configuration properties. We can't use the inbuilt deprecation rules because PHPStan omits private properties from its deprecation checking.

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
