### PR TITLE
Add stub for SiteTree

### DIFF
--- a/.changeset/quick-lobsters-shout.md
+++ b/.changeset/quick-lobsters-shout.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Add stub for SiteTree

--- a/stubs/SilverStripe/CMS/Model/SiteTree.stub
+++ b/stubs/SilverStripe/CMS/Model/SiteTree.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\CMS\Model;
+
+/**
+ * @property ?string $Content HTML content of the page.
+ * @property ?string $MetaDescription
+ */
+class SiteTree
+{
+}


### PR DESCRIPTION
## Description ✍️

- $Content is nullable
- $MetaDescription is nullable
- $URLSegment is technically nullable until the object is saved in the database. However developers are unlikely to access the $URLSegment until the object is saved anyway.

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
