### PR TITLE
Add RequireInjectableCreateToMatchConstructorSignatureRule

### DIFF
--- a/.changeset/spicy-rules-sparkle.md
+++ b/.changeset/spicy-rules-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Add RequireInjectableCreateToMatchConstructorSignatureRule (bleeding edge)

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -1,0 +1,4 @@
+parameters:
+    silverstan:
+        requireInjectableCreateToMatchConstructorSignature:
+            enabled: true

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -62,7 +62,7 @@ final class Foo extends \SilverStripe\ORM\DataObject
 
 ## DisallowNewInstanceOnInjectableRule
 
-Disallow instantiating a `SilverStripe\Core\Injectable` class using `new`. Use `create()` instead.
+Disallow instantiating a `SilverStripe\Core\Injector\Injectable` class using `new`. Use `create()` instead.
 
 :mag_right: **silverstan.injectable.useCreate**
 
@@ -82,7 +82,7 @@ parameters:
 ```php
 final class Foo
 {
-    use \SilverStripe\Core\Injectable;
+    use \SilverStripe\Core\Injector\Injectable;
 }
 
 $foo = new Foo();
@@ -95,7 +95,7 @@ $foo = new Foo();
 ```php
 final class Foo
 {
-    use \SilverStripe\Core\Injectable;
+    use \SilverStripe\Core\Injector\Injectable;
 }
 
 $foo = Foo::create();
@@ -411,6 +411,62 @@ final class Foo extends \SilverStripe\ORM\DataObject
 {
     private static string $table_name = 'Foo';
 }
+```
+
+:+1:
+
+<br>
+
+## RequireInjectableCreateToMatchConstructorRule
+
+Require the `SilverStripe\Core\Injector\Injectable::create()` signature to match the object's constructor.
+
+Currently available via [bleeding edge](../README.md#bleeding-edge-).
+
+:mag_right: **argument.\***<br />
+:mag_right: **arguments.count**
+
+:wrench: **configure it!**
+
+- class: [`Cambis\Silverstan\Rule\StaticMethod\RequireInjectableCreateToMatchConstructorSignatureRule`](../src/Rule/StaticCall/RequireInjectableCreateToMatchConstructorSignatureRule.php)
+
+```yaml
+parameters:
+    silverstan:
+        requireInjectableCreateToMatchConstructorSignature:
+            enabled: true
+```
+
+↓
+
+```php
+final readonly class Foo
+{
+    use SilverStripe\Core\Injector\Injectable;
+
+    public function __construct(public string $bar)
+    {
+    }
+}
+
+Foo::create(1); // Parameter #1 $bar of Foo::create() expects string, int given.
+```
+
+:x:
+
+<br>
+
+```php
+final readonly class Foo
+{
+    use SilverStripe\Core\Injector\Injectable;
+
+    public function __construct(public string $bar)
+    {
+    }
+}
+
+Foo::create('');
 ```
 
 :+1:

--- a/e2e/uncle-cheese-display-logic/src/Controller/BasicController.php
+++ b/e2e/uncle-cheese-display-logic/src/Controller/BasicController.php
@@ -11,14 +11,14 @@ final class BasicController
 {
     public function getProducts(): Criteria
     {
-        $products = FormField::create();
+        $products = FormField::create('Products');
 
         return $products->displayIf('HasProducts')->isChecked();
     }
 
     public function getSizes(): Criteria
     {
-        $sizes = FormField::create();
+        $sizes = FormField::create('Sizes');
 
         return $sizes->hideUnless('ProductType')->isEqualTo('t-shirt')
             ->andIf('Price')->isGreaterThan(10);
@@ -26,14 +26,14 @@ final class BasicController
 
     public function getPayment(): Criteria
     {
-        $payment = FormField::create();
+        $payment = FormField::create('Payment');
 
         return $payment->hideIf('Price')->isEqualTo(0);
     }
 
     public function getShipping(): FormField
     {
-        $shipping = FormField::create();
+        $shipping = FormField::create('Shipping');
 
         return $shipping->displayIf('ProductType')
             ->isEqualTo('furniture')

--- a/rules.neon
+++ b/rules.neon
@@ -32,6 +32,8 @@ parameters:
             enabled: true
         disallowPropertyFetchOnUnsafeDataObject:
             enabled: true
+        requireInjectableCreateToMatchConstructorSignature:
+            enabled: false
         disallowStaticPropertyFetchOnConfigurationProperty:
             enabled: true
 
@@ -80,6 +82,9 @@ parametersSchema:
         disallowPropertyFetchOnUnsafeDataObject: structure([
             enabled: bool()
         ])
+        requireInjectableCreateToMatchConstructorSignature: structure([
+            enabled: bool()
+        ])
         disallowStaticPropertyFetchOnConfigurationProperty: structure([
             enabled: bool()
         ])
@@ -102,6 +107,8 @@ conditionalTags:
         phpstan.rules.rule: %silverstan.disallowPropertyFetchOnConfigForClass.enabled%
     Cambis\Silverstan\Rule\PropertyFetch\DisallowPropertyFetchOnUnsafeDataObjectRule:
         phpstan.rules.rule: %silverstan.disallowPropertyFetchOnUnsafeDataObject.enabled%
+    Cambis\Silverstan\Rule\StaticCall\RequireInjectableCreateToMatchConstructorSignatureRule:
+        phpstan.rules.rule: %silverstan.requireInjectableCreateToMatchConstructorSignature.enabled%
     Cambis\Silverstan\Rule\StaticPropertyFetch\DisallowStaticPropertyFetchOnConfigurationPropertyRule:
         phpstan.rules.rule: %silverstan.disallowStaticPropertyFetchOnConfigurationProperty.enabled%
 
@@ -128,5 +135,7 @@ services:
         class: Cambis\Silverstan\Rule\PropertyFetch\DisallowPropertyFetchOnConfigForClassRule
     -
         class: Cambis\Silverstan\Rule\PropertyFetch\DisallowPropertyFetchOnUnsafeDataObjectRule
+    -
+        class: Cambis\Silverstan\Rule\StaticCall\RequireInjectableCreateToMatchConstructorSignatureRule
     -
         class: Cambis\Silverstan\Rule\StaticPropertyFetch\DisallowStaticPropertyFetchOnConfigurationPropertyRule

--- a/src/Rule/StaticCall/RequireInjectableCreateToMatchConstructorSignatureRule.php
+++ b/src/Rule/StaticCall/RequireInjectableCreateToMatchConstructorSignatureRule.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\Silverstan\Rule\StaticCall;
+
+use Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\Rule;
+use function sprintf;
+
+/**
+ * @implements Rule<StaticCall>
+ *
+ * @see \Cambis\Silverstan\Tests\Rule\StaticCall\RequireInjectableCreateToMatchConstructorSignatureRuleTest
+ */
+final readonly class RequireInjectableCreateToMatchConstructorSignatureRule implements Rule
+{
+    public function __construct(
+        private ClassReflectionAnalyser $classReflectionAnalyser,
+        private FunctionCallParametersCheck $functionCallParametersCheck
+    ) {
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->toLowerString() !== 'create') {
+            return [];
+        }
+
+        $type = null;
+
+        if ($node->class instanceof Expr) {
+            $type = $scope->getType($node->class);
+        }
+
+        if ($node->class instanceof Name) {
+            $type = $scope->resolveTypeByName($node->class);
+        }
+
+        if ($type->getObjectClassReflections() === []) {
+            return [];
+        }
+
+        $classReflection = $type->getObjectClassReflections()[0];
+
+        if (!$this->classReflectionAnalyser->isInjectable($classReflection)) {
+            return [];
+        }
+
+        $constructorReflection = $classReflection->getConstructor();
+        $methodName = sprintf('%s::create()', $classReflection->getDisplayName());
+
+        // @phpstan-ignore phpstanApi.method
+        return $this->functionCallParametersCheck->check(
+            ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $node->getArgs(),
+                $constructorReflection->getVariants(),
+                $constructorReflection->getNamedArgumentsVariants()
+            ),
+            $scope,
+            $constructorReflection->getDeclaringClass()->isBuiltin(),
+            $node,
+            'staticMethod',
+            $constructorReflection->acceptsNamedArguments(),
+            'Method ' . $methodName . ' invoked with %d parameter, %d required.',
+            'Method ' . $methodName . ' invoked with %d parameters, %d required.',
+            'Method ' . $methodName . ' invoked with %d parameter, at least %d required.',
+            'Method ' . $methodName . ' invoked with %d parameters, at least %d required.',
+            'Method ' . $methodName . ' invoked with %d parameter, %d-%d required.',
+            'Method ' . $methodName . ' invoked with %d parameters, %d-%d required.',
+            '%s of method ' . $methodName . ' expects %s, %s given.',
+            '', // no return type for constructor
+            '%s of method ' . $methodName . ' is passed by reference, so it expects variables only.',
+            'Unable to resolve the template type %s in call to method ' . $methodName,
+            'Missing parameter $%s in call to method ' . $methodName . '.',
+            'Unknown parameter $%s in call to method ' . $methodName . '.',
+            'Return type of call to method ' . $methodName . ' contains unresolvable type.',
+            '%s of method ' . $methodName . ' contains unresolvable type.',
+            'Method ' . $methodName . " invoked with %s, but it's not allowed because of @no-named-arguments.",
+        );
+    }
+}

--- a/tests/Rule/StaticCall/Fixture/RequireInjectableCreateToMatch.php
+++ b/tests/Rule/StaticCall/Fixture/RequireInjectableCreateToMatch.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Cambis\Silverstan\Tests\Rule\StaticCall\Fixture;
+
+use Cambis\Silverstan\Tests\Rule\StaticCall\Source\Foo;
+
+Foo::create('bar', 1);
+
+Foo::create();
+
+Foo::create(1, 2);
+
+Foo::create(param1: 2);

--- a/tests/Rule/StaticCall/RequireInjectableCreateToMatchConstructorSignatureRuleTest.php
+++ b/tests/Rule/StaticCall/RequireInjectableCreateToMatchConstructorSignatureRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\Silverstan\Tests\Rule\StaticCall;
+
+use Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser;
+use Cambis\Silverstan\Rule\StaticCall\RequireInjectableCreateToMatchConstructorSignatureRule;
+use Override;
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<RequireInjectableCreateToMatchConstructorSignatureRule>
+ */
+final class RequireInjectableCreateToMatchConstructorSignatureRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/RequireInjectableCreateToMatch.php'], [
+            [
+                'Method Cambis\Silverstan\Tests\Rule\StaticCall\Source\Foo::create() invoked with 0 parameters, 2 required.',
+                9,
+            ],
+            [
+                'Parameter #1 $param1 of method Cambis\Silverstan\Tests\Rule\StaticCall\Source\Foo::create() expects string, int given.',
+                11,
+            ],
+            [
+                'Missing parameter $param2 (int) in call to method Cambis\Silverstan\Tests\Rule\StaticCall\Source\Foo::create().',
+                13,
+            ],
+            [
+                'Parameter $param1 of method Cambis\Silverstan\Tests\Rule\StaticCall\Source\Foo::create() expects string, int given.',
+                13,
+            ],
+        ]);
+    }
+
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../tests.neon',
+        ];
+    }
+
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new RequireInjectableCreateToMatchConstructorSignatureRule(
+            self::getContainer()->getByType(ClassReflectionAnalyser::class),
+            self::getContainer()->getByType(FunctionCallParametersCheck::class) // @phpstan-ignore phpstanApi.classConstant
+        );
+    }
+}

--- a/tests/Rule/StaticCall/Source/Foo.php
+++ b/tests/Rule/StaticCall/Source/Foo.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cambis\Silverstan\Tests\Rule\StaticCall\Source;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\TestOnly;
+
+final readonly class Foo implements TestOnly
+{
+    use Injectable;
+
+    public function __construct(
+        public string $param1,
+        public int $param2
+    ) {
+    }
+}


### PR DESCRIPTION
## Description ✍️

- Add a rule to check if the create method matches the objects constructor

## DoD checklist ✅

- [ ] I have performed a self-review of my code
- [ ] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [ ] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [ ] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [ ] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
