### PR TITLE
Allow property assign in DisallowPropertyFetchOnConfigForClassRule

### DIFF
--- a/.changeset/long-bears-repeat.md
+++ b/.changeset/long-bears-repeat.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Allow property assign in DisallowPropertyFetchOnConfigForClassRule

--- a/src/Rule/PropertyFetch/DisallowPropertyFetchOnConfigForClassRule.php
+++ b/src/Rule/PropertyFetch/DisallowPropertyFetchOnConfigForClassRule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cambis\Silverstan\Rule\PropertyFetch;
 
 use Cambis\Silverstan\Contract\SilverstanRuleInterface;
+use Cambis\Silverstan\NodeVisitor\PropertyFetchAssignedToVisitor;
 use Override;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
@@ -75,6 +76,11 @@ CODE_SAMPLE
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
+        // Allow assignment
+        if ($node->hasAttribute(PropertyFetchAssignedToVisitor::ATTRIBUTE_KEY)) {
+            return [];
+        }
+
         $type = $scope->getType($node->var);
 
         // Ensure the resolved type has class reflections

--- a/tests/Rule/PropertyFetch/Fixture/DisallowPropertyFetch.php
+++ b/tests/Rule/PropertyFetch/Fixture/DisallowPropertyFetch.php
@@ -21,5 +21,7 @@ final class DisallowPropertyFetch implements TestOnly
 
         self::config()->foo;
         self::config()->get('foo');
+
+        self::config()->foo = 'bar';
     }
 }


### PR DESCRIPTION
## Description ✍️

- Allow property assign such as `self::config()->foo = 'bar';`

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
