### PR TITLE
🐛 fix: update Injector::get stub so all types so $constructorArgs can be an array of any type

### DIFF
--- a/.changeset/floppy-areas-spend.md
+++ b/.changeset/floppy-areas-spend.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+update Injector::get to use correct definition for constructorArgs

--- a/stubs/SilverStripe/Core/Injector/Injector.stub
+++ b/stubs/SilverStripe/Core/Injector/Injector.stub
@@ -22,7 +22,7 @@ class Injector
      * service, then a class of the given name is instantiated
      * @param bool $asSingleton If set to false a new instance will be returned.
      * If true a singleton will be returned unless the spec is type=prototype'
-     * @param array<string> $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
+     * @param array<mixed> $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
      * @return T|mixed Instance of the specified object
      * @phpstan-return ($name is class-string<T> ? T : mixed)
      */


### PR DESCRIPTION
## Description ✍️

The current Injector stub says that `$constructorArgs` on the `get` method must be an array of string. This is wrong. This array is passed to the constructor of whatever class is to be instantiated and can be basically anything.

## Fixes 🐛

- https://github.com/Cambis/silverstan/issues/21

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
