### PR TITLE
Allow case insensitive method calls

### DIFF
--- a/.changeset/wild-apes-teach.md
+++ b/.changeset/wild-apes-teach.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Allow case insensitive method calls in ExtensibleClassReflectionExtension

--- a/src/Extension/Reflection/AnnotationClassReflectionExtension.php
+++ b/src/Extension/Reflection/AnnotationClassReflectionExtension.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use function array_key_exists;
+use function strtolower;
 
 /**
  * This extension is used resolve methods and properties declared by annotations.
@@ -53,7 +54,7 @@ final class AnnotationClassReflectionExtension implements MethodsClassReflection
                 return false;
             }
 
-            $this->methodReflections[$classReflection->getCacheKey()][$methodName] = $methodReflection;
+            $this->methodReflections[$classReflection->getCacheKey()][strtolower($methodName)] = $methodReflection;
         }
 
         return true;
@@ -88,6 +89,6 @@ final class AnnotationClassReflectionExtension implements MethodsClassReflection
     #[Override]
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        return $this->methodReflections[$classReflection->getCacheKey()][$methodName];
+        return $this->methodReflections[$classReflection->getCacheKey()][strtolower($methodName)];
     }
 }

--- a/src/Extension/Reflection/ExtensibleClassReflectionExtension.php
+++ b/src/Extension/Reflection/ExtensibleClassReflectionExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use function array_key_exists;
+use function strtolower;
 
 /**
  * This extension resolves `SilverStripe\Core\Extensible` magic methods and properties.
@@ -22,7 +23,7 @@ use function array_key_exists;
 final class ExtensibleClassReflectionExtension implements MethodsClassReflectionExtension, PropertiesClassReflectionExtension
 {
     /**
-     * @var MethodReflection[][]
+     * @var array<string, array<non-empty-lowercase-string, MethodReflection>>
      */
     private array $methodReflections = [];
 
@@ -57,7 +58,7 @@ final class ExtensibleClassReflectionExtension implements MethodsClassReflection
 
         $methodReflections = $this->resolveInjectedMethodReflections($classReflection);
 
-        $methodReflection = $methodReflections[$methodName] ?? null;
+        $methodReflection = $methodReflections[strtolower($methodName)] ?? null;
 
         return $methodReflection instanceof MethodReflection;
     }
@@ -92,7 +93,7 @@ final class ExtensibleClassReflectionExtension implements MethodsClassReflection
             return $this->annotationClassReflectionExtension->getMethod($classReflection, $methodName);
         }
 
-        return $this->methodReflections[$classReflection->getCacheKey()][$methodName];
+        return $this->methodReflections[$classReflection->getCacheKey()][strtolower($methodName)];
     }
 
     #[Override]

--- a/src/ReflectionResolver/Contract/MethodReflectionResolverInterface.php
+++ b/src/ReflectionResolver/Contract/MethodReflectionResolverInterface.php
@@ -25,7 +25,7 @@ interface MethodReflectionResolverInterface
     public function getConfigurationPropertyName(): string;
 
     /**
-     * @return MethodReflection[]
+     * @return array<non-empty-lowercase-string, MethodReflection>
      */
     public function resolve(ClassReflection $classReflection): array;
 }

--- a/src/ReflectionResolver/Contract/PropertyReflectionResolverInterface.php
+++ b/src/ReflectionResolver/Contract/PropertyReflectionResolverInterface.php
@@ -25,7 +25,7 @@ interface PropertyReflectionResolverInterface
     public function getConfigurationPropertyName(): string;
 
     /**
-     * @return PropertyReflection[]
+     * @return array<non-empty-string, PropertyReflection>
      */
     public function resolve(ClassReflection $classReflection): array;
 }

--- a/src/ReflectionResolver/ReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver.php
@@ -37,7 +37,7 @@ final class ReflectionResolver
      * Resolve all injected property reflections using the registered resolvers.
      *
      * @see \Cambis\Silverstan\ReflectionResolver\Contract\PropertyReflectionResolverInterface
-     * @return PropertyReflection[]
+     * @return array<non-empty-string, PropertyReflection>
      */
     public function resolveInjectedPropertyReflections(ClassReflection $classReflection): array
     {
@@ -54,7 +54,7 @@ final class ReflectionResolver
      * Resolve all injected method reflections using the registered resolvers.
      *
      * @see \Cambis\Silverstan\ReflectionResolver\Contract\MethodReflectionResolverInterface
-     * @return MethodReflection[]
+     * @return array<non-empty-lowercase-string, MethodReflection>
      */
     public function resolveInjectedMethodReflections(ClassReflection $classReflection): array
     {

--- a/src/ReflectionResolver/ReflectionResolver/DisplayLogicCriteriaComparisonsMethodReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver/DisplayLogicCriteriaComparisonsMethodReflectionResolver.php
@@ -16,6 +16,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use function is_array;
+use function strtolower;
 
 /**
  * Resolves magic comparison methods from `UncleCheese\DisplayLogic\Criteria`.
@@ -53,9 +54,9 @@ final readonly class DisplayLogicCriteriaComparisonsMethodReflectionResolver imp
         $parameters = [new ExtensibleParameterReflection('val', new MixedType(), PassedByReference::createNo(), true, true, new NullType())];
         $returnType = new ObjectType('UncleCheese\DisplayLogic\Criteria');
 
-        /** @var string[] $comparisons */
+        /** @var non-empty-string[] $comparisons */
         foreach ($comparisons as $comparison) {
-            $methodReflections[$comparison] = new ExtensibleMethodReflection($comparison, $classReflection, $returnType, $parameters, false, true, null, TemplateTypeMap::createEmpty());
+            $methodReflections[strtolower($comparison)] = new ExtensibleMethodReflection($comparison, $classReflection, $returnType, $parameters, false, true, null, TemplateTypeMap::createEmpty());
         }
 
         return $methodReflections;

--- a/src/ReflectionResolver/ReflectionResolver/ExtensionMethodReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver/ExtensionMethodReflectionResolver.php
@@ -13,6 +13,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use ReflectionMethod;
 use function array_unique;
 use function is_array;
+use function strtolower;
 
 final readonly class ExtensionMethodReflectionResolver implements MethodReflectionResolverInterface
 {
@@ -79,7 +80,10 @@ final readonly class ExtensionMethodReflectionResolver implements MethodReflecti
                     continue;
                 }
 
-                $methodReflections[$reflectionMethod->getName()] = $extendedMethodReflection;
+                /** @var non-empty-lowercase-string $methodName */
+                $methodName = strtolower($reflectionMethod->getName());
+
+                $methodReflections[$methodName] = $extendedMethodReflection;
             }
         }
 

--- a/src/ReflectionResolver/ReflectionResolver/ResponsiveImageSetsMethodReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver/ResponsiveImageSetsMethodReflectionResolver.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
 use function array_keys;
 use function is_array;
+use function strtolower;
 
 /**
  * Resolves magic sets methods from `Heyday\ResponsiveImages\ResponsiveImageExtension`.
@@ -50,8 +51,9 @@ final readonly class ResponsiveImageSetsMethodReflectionResolver implements Meth
 
         $returnType = new ObjectType('SilverStripe\ORM\FieldType\DBHTMLText');
 
+        /** @var non-empty-string $set */
         foreach (array_keys($sets) as $set) {
-            $methodReflections[$set] = new ExtensibleMethodReflection($set, $classReflection, $returnType, [], false, false, null, TemplateTypeMap::createEmpty());
+            $methodReflections[strtolower($set)] = new ExtensibleMethodReflection($set, $classReflection, $returnType, [], false, false, null, TemplateTypeMap::createEmpty());
         }
 
         return $methodReflections;

--- a/src/ReflectionResolver/ReflectionResolver/SimpleRelationMethodReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver/SimpleRelationMethodReflectionResolver.php
@@ -11,6 +11,7 @@ use Cambis\Silverstan\TypeResolver\TypeResolver;
 use Override;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use function strtolower;
 
 final readonly class SimpleRelationMethodReflectionResolver implements MethodReflectionResolverInterface
 {
@@ -39,7 +40,7 @@ final readonly class SimpleRelationMethodReflectionResolver implements MethodRef
         $methodReflections = [];
 
         foreach ($types as $name => $type) {
-            $methodReflections[$name] = new ExtensibleMethodReflection($name, $classReflection, $type, [], false, false, null, TemplateTypeMap::createEmpty());
+            $methodReflections[strtolower($name)] = new ExtensibleMethodReflection($name, $classReflection, $type, [], false, false, null, TemplateTypeMap::createEmpty());
         }
 
         return $methodReflections;

--- a/src/TypeResolver/Contract/MethodTypeResolverInterface.php
+++ b/src/TypeResolver/Contract/MethodTypeResolverInterface.php
@@ -31,7 +31,7 @@ interface MethodTypeResolverInterface
     public function getExcludeMiddleware(): true|int;
 
     /**
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolve(ClassReflection $classReflection): array;
 }

--- a/src/TypeResolver/Contract/PropertyTypeResolverInterface.php
+++ b/src/TypeResolver/Contract/PropertyTypeResolverInterface.php
@@ -31,7 +31,7 @@ interface PropertyTypeResolverInterface
     public function getExcludeMiddleware(): true|int;
 
     /**
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolve(ClassReflection $classReflection): array;
 }

--- a/src/TypeResolver/TypeResolver.php
+++ b/src/TypeResolver/TypeResolver.php
@@ -46,7 +46,7 @@ final readonly class TypeResolver
      * Does not resolve implementors of `Cambis\Silverstan\TypeResolver\Contract\LazyTypeResolverInterface`.
      *
      * @see \Cambis\Silverstan\TypeResolver\Contract\PropertyTypeResolverInterface
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolveInjectedPropertyTypes(ClassReflection $classReflection): array
     {
@@ -67,7 +67,7 @@ final readonly class TypeResolver
      * Resolve injected property types using the registered resolvers.
      *
      * @see \Cambis\Silverstan\TypeResolver\Contract\PropertyTypeResolverInterface
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolveInjectedPropertyTypesFromConfigurationProperty(ClassReflection $classReflection, string $propertyName): array
     {
@@ -86,7 +86,7 @@ final readonly class TypeResolver
      * Resolve injected method types using the registered resolvers.
      *
      * @see \Cambis\Silverstan\TypeResolver\Contract\MethodTypeResolverInterface
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolveInjectedMethodTypesFromConfigurationProperty(ClassReflection $classReflection, string $propertyName): array
     {
@@ -106,7 +106,7 @@ final readonly class TypeResolver
      * Does not resolve implementors of `Cambis\Silverstan\TypeResolver\Contract\LazyTypeResolverInterface`.
      *
      * @see \Cambis\Silverstan\TypeResolver\Contract\MethodTypeResolverInterface
-     * @return Type[]
+     * @return array<non-empty-string, Type>
      */
     public function resolveInjectedMethodTypes(ClassReflection $classReflection): array
     {

--- a/tests/Extension/Reflection/Fixture/ExtensionMethodReflections.php
+++ b/tests/Extension/Reflection/Fixture/ExtensionMethodReflections.php
@@ -8,8 +8,10 @@ use function PHPStan\Testing\assertType;
 $foo = Foo::create();
 
 assertType('bool', $foo->publicMethod(true));
+assertType('bool', $foo->PublicMethod(true)); // Wrong case but still valid PHP
 assertType('*ERROR*', $foo->protectedMethod(true));
 assertType('*ERROR*', $foo->privateMethod(true));
 assertType('*ERROR*', $foo::publicStaticMethod(true));
 
 assertType('Cambis\Silverstan\Tests\Extension\Reflection\Source\Model\Foo', $foo->ExtensionHasOne());
+assertType('Cambis\Silverstan\Tests\Extension\Reflection\Source\Model\Foo', $foo->extensionHasOne()); // Wrong case but still valid PHP

--- a/tests/Extension/Reflection/Fixture/SimpleRelationMethodReflections.php
+++ b/tests/Extension/Reflection/Fixture/SimpleRelationMethodReflections.php
@@ -9,6 +9,7 @@ $foo = Foo::create();
 
 // belongs_to
 assertType(Foo::class, $foo->Parent());
+assertType(Foo::class, $foo->parent()); // Wrong case but still valid PHP
 
 // has_one
 assertType(Foo::class, $foo->Child());


### PR DESCRIPTION
## Description ✍️

- Calls to injected case insensitive methods is still valid PHP, don't report them as undefined.
- Improve internal php doc types with lower-string

## Fixes 🐛

- Link to github issue(s) here.

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
