### PR TITLE
Add support for PHPStan 2.1.28

### DIFF
--- a/.changeset/poor-falcons-give.md
+++ b/.changeset/poor-falcons-give.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstan": patch
+---
+
+Add support for PHPStan 2.1.28

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -17,7 +17,7 @@
     "php": "^7.4 || ^8.0",
     "ext-tokenizer": "*",
     "composer/class-map-generator": "^1.5",
-    "phpstan/phpstan": "^2.1.12",
+    "phpstan/phpstan": "^2.1.28",
     "silverstripe/config": "^1.4 || ^2.0 || ^3.0"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "ext-tokenizer": "*",
         "composer/class-map-generator": "^1.5",
-        "phpstan/phpstan": "^2.1.12",
+        "phpstan/phpstan": "^2.1.28",
         "silverstripe/config": "^1.4 || ^2.0 || ^3.0"
     },
     "require-dev": {
@@ -37,6 +37,9 @@
         "symplify/easy-coding-standard": "^12.0",
         "symplify/phpstan-rules": "^14.0",
         "tomasvotruba/unused-public": "^2.0"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": ">=4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRecto
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
@@ -20,11 +21,11 @@ return RectorConfig::configure()
         php83: true
     )
     ->withPreparedSets(
+        deadCode: true,
         codeQuality: true,
         codingStyle: true,
-        deadCode: true,
-        earlyReturn: true,
-        privatization: true
+        privatization: true,
+        earlyReturn: true
     )
     ->withRules([
         DeclareStrictTypesRector::class,
@@ -43,5 +44,8 @@ return RectorConfig::configure()
         StringClassNameToClassConstantRector::class,
         UseClassKeywordForClassNameResolutionRector::class => [
             __DIR__ . '/tests',
+        ],
+        RemoveReflectionSetAccessibleCallsRector::class => [
+            __DIR__ . '/src/ConfigurationResolver/Middleware/PrivateStaticMiddleware.php',
         ],
     ]);

--- a/src/ReflectionResolver/ReflectionResolver/DBPropertyReflectionResolver.php
+++ b/src/ReflectionResolver/ReflectionResolver/DBPropertyReflectionResolver.php
@@ -77,8 +77,8 @@ final readonly class DBPropertyReflectionResolver implements PropertyReflectionR
         }
 
         // Attempt to return the type from the property
-        if ($fieldClassReflection->hasProperty('value')) {
-            return $fieldClassReflection->getProperty('value', new OutOfClassScope())->getReadableType();
+        if ($fieldClassReflection->hasInstanceProperty('value')) {
+            return $fieldClassReflection->getInstanceProperty('value', new OutOfClassScope())->getReadableType();
         }
 
         // Fallback, return the original type
@@ -112,8 +112,8 @@ final readonly class DBPropertyReflectionResolver implements PropertyReflectionR
         }
 
         // Attempt to return the type from the property
-        if ($fieldClassReflection->hasProperty('value')) {
-            return $fieldClassReflection->getProperty('value', new OutOfClassScope())->getWritableType();
+        if ($fieldClassReflection->hasInstanceProperty('value')) {
+            return $fieldClassReflection->getInstanceProperty('value', new OutOfClassScope())->getWritableType();
         }
 
         // Fallback, return the original type

--- a/src/Rule/StaticPropertyFetch/DisallowStaticPropertyFetchOnConfigurationPropertyRule.php
+++ b/src/Rule/StaticPropertyFetch/DisallowStaticPropertyFetchOnConfigurationPropertyRule.php
@@ -70,11 +70,11 @@ final readonly class DisallowStaticPropertyFetchOnConfigurationPropertyRule impl
             return [];
         }
 
-        if ($type->hasProperty($node->name->name)->no()) {
+        if ($type->hasStaticProperty($node->name->name)->no()) {
             return [];
         }
 
-        $propertyReflection = $classReflection->getProperty($node->name->name, $scope);
+        $propertyReflection = $classReflection->getStaticProperty($node->name->name);
 
         if (!$this->propertyReflectionAnalyser->isConfigurationProperty($propertyReflection)) {
             return [];

--- a/src/Type/TypeSpecifyingExtension/ExtensibleHasExtensionTypeSpecifyingExtension.php
+++ b/src/Type/TypeSpecifyingExtension/ExtensibleHasExtensionTypeSpecifyingExtension.php
@@ -33,7 +33,9 @@ final class ExtensibleHasExtensionTypeSpecifyingExtension implements MethodTypeS
     private TypeSpecifier $typeSpecifier;
 
     public function __construct(
-        /** @var class-string */
+        /**
+         * @var class-string
+         */
         private readonly string $className,
         private readonly ClassReflectionAnalyser $classReflectionAnalyser,
         private readonly TypeFactory $typeFactory,

--- a/src/Type/TypeSpecifyingExtension/ExtensibleHasMethodTypeSpecifyingExtension.php
+++ b/src/Type/TypeSpecifyingExtension/ExtensibleHasMethodTypeSpecifyingExtension.php
@@ -34,7 +34,9 @@ final class ExtensibleHasMethodTypeSpecifyingExtension implements MethodTypeSpec
     private TypeSpecifier $typeSpecifier;
 
     public function __construct(
-        /** @var class-string */
+        /**
+         * @var class-string
+         */
         private readonly string $className,
         private readonly ClassReflectionAnalyser $classReflectionAnalyser,
         private readonly TypeFactory $typeFactory,

--- a/src/TypeResolver/TypeResolver/SimpleRelationPropertyTypeResolver.php
+++ b/src/TypeResolver/TypeResolver/SimpleRelationPropertyTypeResolver.php
@@ -20,7 +20,7 @@ final readonly class SimpleRelationPropertyTypeResolver implements PropertyTypeR
         /**
          * @var true|int-mask-of<ConfigurationResolver::EXCLUDE_*>
          */
-        private readonly true|int $excludeMiddleware = ConfigurationResolver::EXCLUDE_NONE
+        private true|int $excludeMiddleware = ConfigurationResolver::EXCLUDE_NONE
     ) {
     }
 


### PR DESCRIPTION
## Description ✍️
- remove calls to depreacted hasProperty/getProperty
- fix issue with ecs phpcs compat
- run the test suite weekly

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstan/blob/main/CONTRIBUTING.md#making-a-pull-request-).
